### PR TITLE
Fix calculation of `tamax` in `sdfResponse`

### DIFF
--- a/SRC/interpreter/OpenSeesMiscCommands.cpp
+++ b/SRC/interpreter/OpenSeesMiscCommands.cpp
@@ -1941,7 +1941,7 @@ int OPS_sdfResponse()
 	}
 	if (fabs(a) > amax) {
 	    amax = fabs(a);
-	    tamax = iter*dt;
+	    tamax = i*dt;
 	}
     }
   


### PR DESCRIPTION
The wrong iterating variable was being used to calculate `tamax` -- the internal Newton `iter` instead of the index of the applied force `i`.